### PR TITLE
display error in nginx logs

### DIFF
--- a/nginx/access.lua
+++ b/nginx/access.lua
@@ -1,5 +1,8 @@
 -- Convert the Ip to integer, and check if present in sqlite
 ok, err = require "CrowdSec".allowIp(ngx.var.remote_addr)
+if err ~= nil then 
+    ngx.log(ngx.ERR, "[Crowdsec] bouncer error " .. err)
+end
 if ok == nil then
    ngx.log(ngx.ERR, "[Crowdsec] " .. err)
 end


### PR DESCRIPTION
when the bouncer returns an error (https://github.com/crowdsecurity/lua-cs-bouncer/pull/5), display it in the nginx error log for the user to see.
