### PR TITLE
doc: make documentation README's link work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <img src="https://img.shields.io/badge/tests-pass-green">
 </p>
 <p align="center">
-&#x1F4DA; <a href="#installation/">Documentation</a>
+&#x1F4DA; <a href="#installation">Documentation</a>
 &#x1F4A0; <a href="https://hub.crowdsec.net">Hub</a>
 &#128172; <a href="https://discourse.crowdsec.net">Discourse </a>
 </p>


### PR DESCRIPTION
# Context

There was a trailing slash that broke the "documentation" link in the header of the `README`: nothing happens when the link is clicked.

The link before the fix:

```
https://github.com/crowdsecurity/cs-nginx-bouncer#installation/
```

# Content

I removed the trailing slash to fix the link.

The link after the fix:

```
https://github.com/crowdsecurity/cs-nginx-bouncer#installation
```