### PR TITLE
Add `resolver` to crowdsec_nginx.conf

### DIFF
--- a/nginx/crowdsec_nginx.conf
+++ b/nginx/crowdsec_nginx.conf
@@ -1,5 +1,6 @@
 lua_package_path '/usr/local/lua/crowdsec/?.lua;;';
 lua_shared_dict crowdsec_cache 50m;
+resolver 1.0.0.1 ipv6=off;
 lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 init_by_lua_block {
         cs = require "crowdsec"


### PR DESCRIPTION
When the bouncer tries to validate the captcha with the captcha service selected by the user it fails with `[lua] crowdsec.lua:689: Allow(): Error while validating captcha: no resolver defined to resolve "example.com"` in the error logs of NGINX/Openresty without sending the request to the captcha service making the captcha useless because the form can be filled with anything and It will pass.

The https://docs.crowdsec.net/u/bouncers/nginx/#nginx-configuration pages shows `resolver 8.8.8.8 ipv6=off;` and when I added that to the configuration, the bouncer was able to verify key with the captcha backend selected.

Feel free to change the resolver used.