### PR TITLE
add init worker by lua

### DIFF
--- a/nginx/crowdsec_nginx.conf
+++ b/nginx/crowdsec_nginx.conf
@@ -24,3 +24,17 @@ access_by_lua_block {
 		cs.Allow(ngx.var.remote_addr)
 	end
 }
+
+init_worker_by_lua_block {
+        cs = require "crowdsec"
+        local mode = cs.get_mode()
+        if string.lower(mode) == "stream" then
+           ngx.log(ngx.INFO, "Initilizing stream mode for worker " .. tostring(ngx.worker.id()))
+           cs.SetupStream()
+        end
+
+        if ngx.worker.id() == 0 then
+           ngx.log(ngx.INFO, "Initilizing metrics for worker " .. tostring(ngx.worker.id()))
+           cs.SetupMetrics()
+        end
+}


### PR DESCRIPTION
Add an init worker by lua to the configuration to fire SetupStream and SetupMetrics.

cf. https://github.com/crowdsecurity/lua-cs-bouncer/pull/105
